### PR TITLE
Adding mkdir for output ebin dir.

### DIFF
--- a/lib/mix_protobuffs.ex
+++ b/lib/mix_protobuffs.ex
@@ -47,6 +47,7 @@ defmodule Mix.Tasks.Compile.Protobuffs do
     if files == [] do
       :noop
     else
+      File.mkdir(options[:output_ebin_dir])  # create "ebin" if necessary
       File.mkdir(options[:output_include_dir])  # create "src" if necessary
       compile_files(files, options)
       generate_wrappers(files, options)


### PR DESCRIPTION
The task of compiling proto wheel before the compilation of the sources of the project, in this case ebin destination folder may not exist.

This change attempts to create the folder if it does not exist preventing a build error.
